### PR TITLE
Fix the executable to work with multiple installs / non-global installs.

### DIFF
--- a/bin/require-analyzer
+++ b/bin/require-analyzer
@@ -7,7 +7,7 @@ var fs = require('fs'),
     eyes = require('eyes'),
     winston = require('winston'),
     argv = require('optimist').argv,
-    analyzer = require('require-analyzer');
+    analyzer = require('../');
 
 var help = [
   'usage: require-analyzer [options] [directory]',
@@ -83,7 +83,6 @@ function listDependencies (pkg, msgs) {
   })
 }
 
-console.log(argv)
 var dir = process.cwd(), 
     source = argv._[0], 
     pkgFile;


### PR DESCRIPTION
[fix] use relative require, the symlink for executable is realpathed so its fine to use relatives, thanks isaacs
