### PR TITLE
display full path of file if not a package.

### DIFF
--- a/bin/find-dependencies
+++ b/bin/find-dependencies
@@ -6,14 +6,15 @@ var Module = require('module').Module,
 
 //
 // Monkey punch `Module._load()` to observe the names
-// of packages as they are loaded. 
+// of packages as they are loaded.
 //
-Module._load = function (name) {
+Module._load = function (name, parent) {
+  name = /^[./]/.test(name) ? Module._resolveFilename(name, parent)[1] : name;
   console.log('__!load::' + name);
   return __load.apply(Module, arguments);
 }
 
-try {    
+try {
 
   process.nextTick(function () {
     process.exit(0);


### PR DESCRIPTION
If you are looking at the raw file dependencies for local files, seeing the full path is super useful.

Currently the output for analyzing options like <code> { target: '../test/foo.js', raw: true }</code> might look something like this:

```
[ '../test/foo.js', './bar', 'underscore' ]
```

The problem being that <code>'./bar'</code> is relative to foo's dir position -- which is hard to tell from the dependencies result.

This pull request proposes instead returning the local files full path -- so the above would instead look something like this:

```
[ '/Users/jacob/workspace/play/test/foo.js',
  '/Users/jacob/workspace/play/test/bar.js',
  'underscore' ]
```
