### PR TITLE
Default to using app.js or server.js for main if not present in package.json.

### DIFF
--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -416,7 +416,7 @@ analyzer.package = function (options, callback) {
         setMain(pkg, newoptions, setTarget);
       }
       else {
-        setTarget(callback);
+        setTarget(pkg, newoptions);
       }
     }
     catch (ex) {


### PR DESCRIPTION
Currently if you try to use require-analyzer on a package.json file that does not have "main" present, it will fail with an error. This fix will fall back to using server.js or app.js if "main" is missing and they are present.
