### PR TITLE
Fixed indexOf called on Object when # deps = 0

### DIFF
--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -163,7 +163,7 @@ analyzer.npmAnalyze = function (deps, options, callback) {
         }
         Object.keys(result.dependencies).forEach(function (pkg) {
           if (result.devDependencies && pkg in result.devDependencies) return;
-          if (!Array.isArray(deps) && Object.keys(deps).length !== 0) {
+          if (!Array.isArray(deps)) {
             if (deps[pkg] === '*' || typeof deps[pkg] === 'undefined') {
               pkgs[pkg] = result.dependencies[pkg]
                           ? result.dependencies[pkg]['version']


### PR DESCRIPTION
require-analyzer breaks if no dependencies are found in the scanned files. Pull request fixes the following example:

`./lib/index.js`:

``` javascript
//nothing to scan here!
```

`package.json`:

``` javascript
{
    "main": "./lib/index.js",
    "dependencies": {
    }
}
```
