### PR TITLE
Fix TypeError in case of missing node_modules dir

### DIFF
--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -175,7 +175,7 @@ analyzer.npmAnalyze = function (deps, options, callback) {
           suspect = {};
 
       Object.keys(deps).forEach(function (dep) {
-        if (dep in pkgs && pkgs[dep].dependencies) {
+        if (pkgs[dep] && pkgs[dep].dependencies) {
           Object.keys(pkgs[dep].dependencies).forEach(function (cdep) {
             if (cdep in reduced) {
               suspect[cdep] = pkgs[cdep];


### PR DESCRIPTION
If you run `require-analyzer` on a directory without a `node_modules` directory, you get the following error:

```
/usr/local/share/npm/lib/node_modules/require-analyzer/lib/require-analyzer.js:178
        if (dep in pkgs && pkgs[dep].dependencies) {
                                                 ^
TypeError: Cannot read property 'dependencies' of undefined
    at analyzer.npmAnalyze (/usr/local/share/npm/lib/node_modules/require-analyzer/lib/require-analyzer.js:178:50)
    at Array.forEach (native)
    at analyzer.npmAnalyze (/usr/local/share/npm/lib/node_modules/require-analyzer/lib/require-analyzer.js:177:25)
    at /usr/local/share/npm/lib/node_modules/require-analyzer/node_modules/read-installed/read-installed.js:118:5
    at /usr/local/share/npm/lib/node_modules/require-analyzer/node_modules/read-installed/read-installed.js:234:14
    at asyncMap (/usr/local/share/npm/lib/node_modules/require-analyzer/node_modules/read-installed/node_modules/slide/lib/async-map.js:27:18)
    at next (/usr/local/share/npm/lib/node_modules/require-analyzer/node_modules/read-installed/read-installed.js:200:5)
    at /usr/local/share/npm/lib/node_modules/require-analyzer/node_modules/read-installed/read-installed.js:157:7
    at LOOP (fs.js:1138:14)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

This commit fixes that.