### PR TITLE
Provide a clearer error msg if main not found

### DIFF
--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -358,7 +358,10 @@ analyzer.package = function (options, callback) {
         var newPath = path.join(newoptions.target, pkg.main ? path.normalize(pkg.main) : '/'),
             newTarget = analyzer.resolve(newPath);
 
-        if (newTarget === false) {
+        if (!pkg.main) {
+          todo = 1;
+          dequeue(new Error('Couldn\'t find a \'main\' entry in package.json'));
+        } else if (newTarget === false) {
           todo = 1;
           dequeue(new Error('Couldn\'t resolve path ' + newPath));
         }

--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -358,19 +358,20 @@ analyzer.package = function (options, callback) {
         var newPath = path.join(newoptions.target, pkg.main ? path.normalize(pkg.main) : '/'),
             newTarget = analyzer.resolve(newPath);
 
-        if (!pkg.main) {
+        if (newTarget === false) {
           todo = 1;
-          dequeue(new Error('Couldn\'t find a \'main\' entry in package.json'));
-        } else if (newTarget === false) {
-          todo = 1;
-          dequeue(new Error('Couldn\'t resolve path ' + newPath));
+          if (!pkg.main) {
+            dequeue(new Error('Couldn\'t find a \'main\' entry in package.json'));
+          } else {
+            dequeue(new Error('Couldn\'t resolve path ' + newPath));
+          }
         }
         return processOptions(newoptions);
       }
 
       // add logic to default to app.js or server.js for main if main is not present.
       if ( !('main' in pkg) || pkg.main === '') {
-        setMain(['app.js', 'server.js', 'index.js'], pkg, newoptions, setTarget);
+        setMain(['app.js', 'server.js'], pkg, newoptions, setTarget);
       }
       else {
         setTarget(pkg, newoptions);


### PR DESCRIPTION
Otherwise you'll get a `Couldn't resolve path <base dir>` error message, which is both a lie and not representative of the underlying problem.

This is only thrown after checking for the default `app.js`, `server.js` and `index.js` files and not finding any of them.