### PR TITLE
Fix for wildcard characters in dependency's version field

### DIFF
--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -175,7 +175,7 @@ analyzer.npmAnalyze = function (deps, options, callback) {
           suspect = {};
 
       Object.keys(deps).forEach(function (dep) {
-        if (dep in pkgs && pkgs[dep].dependencies) {
+        if (dep in pkgs && pkgs[dep] !== undefined && pkgs[dep].dependencies) {
           Object.keys(pkgs[dep].dependencies).forEach(function (cdep) {
             if (cdep in reduced) {
               suspect[cdep] = pkgs[cdep];

--- a/lib/require-analyzer.js
+++ b/lib/require-analyzer.js
@@ -175,7 +175,7 @@ analyzer.npmAnalyze = function (deps, options, callback) {
           suspect = {};
 
       Object.keys(deps).forEach(function (dep) {
-        if (dep in pkgs && pkgs[dep] !== undefined && pkgs[dep].dependencies) {
+        if (pkgs[dep] !== undefined && pkgs[dep].dependencies) {
           Object.keys(pkgs[dep].dependencies).forEach(function (cdep) {
             if (cdep in reduced) {
               suspect[cdep] = pkgs[cdep];


### PR DESCRIPTION
If the dependencies use wildcard characters in the version field (although its not recommended, it is possible), like below
```
  "dependencies": {
    "mongodb": "*"
  }
```
require-analyzer fails with the following error
```
C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\lib\require-analyzer.js:178
        if (dep in pkgs && pkgs[dep].dependencies) {
                                    ^
TypeError: Cannot read property 'dependencies' of undefined
    at C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\lib\require-analyzer.js:180:37
    at Array.forEach (native)
    at C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\lib\require-analyzer.js:177:25
    at C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\read-installed.js:118:5
    at C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\read-installed.js:234:14
    at asyncMap (C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\node_modules\slide\lib\async-map.js:27:18)
    at next (C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\read-installed.js:200:5)
    at C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\read-installed.js:145:12
    at C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\node_modules\read-package-json\read-json.js:53:40
    at final (C:\Users\thefourtheye\AppData\Roaming\npm\node_modules\require-analyzer\node_modules\read-installed\node_modules\read-package-json\read-json.js:311:17)
```