### PR TITLE
Small fix to CLI help: add missing 'not' word

### DIFF
--- a/bin/require-analyzer
+++ b/bin/require-analyzer
@@ -18,7 +18,7 @@ var help = [
   '  -d, --dir    Directory to check for package.json',
   '  --update     Update versions for existing dependencies',
   '  -f, --file   File to check for instead of package.json.',
-  '  --safe       display existing dependencies but do change package.json',
+  '  --safe       display existing dependencies but do not change package.json',
   '  -h, --help   You\'re staring at it'
 ].join('\n');
 


### PR DESCRIPTION
--safe was having incorrect statement about its behavior.
Added the missing 'not' word.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nodejitsu/require-analyzer/66)
<!-- Reviewable:end -->
